### PR TITLE
feat(login): add hook for login + interceptor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   extends: ['airbnb-typescript-prettier'],
+  ignorePatterns: ['.eslintrc.js'],
   // Rules can be here to override the preset of eslint from airbnb, if they are too strict.
   rules: {
     '@typescript-eslint/ban-ts-comment': 'off',
@@ -22,6 +23,8 @@ module.exports = {
     'no-console': 'off',
 
     'react/destructuring-assignment': 0,
+    'react/jsx-props-no-spreading': 'off',
+    'import/prefer-default-export': 0,
     // 'react/prop-types': 0, -> this is an example
   },
   overrides: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2872,6 +2872,14 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
       "integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ=="
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1273,6 +1273,11 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "@hookform/resolvers": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-1.3.4.tgz",
+      "integrity": "sha512-K56VLSInXNIT/r14pkzRn1FJclqzGOWqpe3Bf0kz2Hf98ZOmRRFh4fhB7F3ofqCQ03CEQQkV44CTg7ql6nEvEg=="
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2025,6 +2030,11 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
+    "@types/lodash": {
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -10039,6 +10049,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
+    "nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
+    },
     "nanoid": {
       "version": "3.1.20",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
@@ -12297,6 +12312,11 @@
         "react-is": "^16.8.1"
       }
     },
+    "property-expr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.4.tgz",
+      "integrity": "sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg=="
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -12630,6 +12650,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "react-hook-form": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.1.tgz",
+      "integrity": "sha512-bL0LQuQ3OlM3JYfbacKtBPLOHhmgYz8Lj6ivMrvu2M6e1wnt4sbGRtPEPYCc/8z3WDbjrMwfAfLX92OsB65pFA=="
     },
     "react-icons": {
       "version": "4.2.0",
@@ -15153,6 +15178,11 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA="
+    },
     "tough-cookie": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -17183,6 +17213,20 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "yup": {
+      "version": "0.32.8",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.8.tgz",
+      "integrity": "sha512-SZulv5FIZ9d5H99EN5tRCRPXL0eyoYxWIP1AacCrjC9d4DfP13J1dROdKGfpfRHT3eQB6/ikBl5jG21smAfCkA==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@types/lodash": "^4.14.165",
+        "lodash": "^4.17.20",
+        "lodash-es": "^4.17.11",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "axios": "^0.21.1",
     "brace": "^0.11.1",
     "jsoneditor": "^9.1.9",
     "jsoneditor-react": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@hookform/resolvers": "^1.3.4",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
@@ -13,13 +14,15 @@
     "node-sass": "^4.14.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-hook-form": "^6.15.1",
     "react-icons": "^4.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^2.0.3",
     "typescript": "^4.1.3",
-    "web-vitals": "^0.2.4"
+    "web-vitals": "^0.2.4",
+    "yup": "^0.32.8"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,8 @@ import { ProtectedRoute } from './shared/ProtectedRoute';
 
 function App(): JSX.Element {
   // Handle user state
-  // Ask if we should have this instead directly in a utils instead
-  const [isLoggedIn, setLoggedIn] = useState(false);
+  const accessToken = localStorage.getItem(storageNames.user) || '';
+  const [isLoggedIn, setLoggedIn] = useState(!!accessToken);
 
   // Handle user login by setting the storage and state
   const login = (token: string): void => {
@@ -26,7 +26,6 @@ function App(): JSX.Element {
     localStorage.removeItem(storageNames.user);
   };
 
-  // TODO: still need to handle the first time getting to site ( if token still valid, present etc. )
   return (
     <UserContext.Provider value={{ isLoggedIn, login, logout }}>
       <Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,44 @@
-import React from 'react';
-import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
-import BaseLayout from './components/layouts/BaseLayout';
-import IpfsList from './pages/ipfs/IpfsList';
-import Ipfs from './pages/ipfs/Ipfs';
-
+import React, { useState } from 'react';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import './App.scss';
+import BaseLayout from './components/layouts/BaseLayout';
+import { storageNames } from './config';
+import UserContext from './hooks/UserContext';
+import Ipfs from './pages/ipfs/Ipfs';
+import IpfsList from './pages/ipfs/IpfsList';
+import Login from './pages/Login/Login';
+import { ProtectedRoute } from './shared/ProtectedRoute';
 
 function App(): JSX.Element {
+  // Handle user state
+  // Ask if we should have this instead directly in a utils instead
+  const [isLoggedIn, setLoggedIn] = useState(false);
+
+  // Handle user login by setting the storage and state
+  const login = (token: string): void => {
+    setLoggedIn(true);
+    localStorage.setItem(storageNames.user, token);
+  };
+
+  // Handle user logout
+  const logout = (): void => {
+    setLoggedIn(false);
+    localStorage.removeItem(storageNames.user);
+  };
+
+  // TODO: still need to handle the first time getting to site ( if token still valid, present etc. )
   return (
-    <Router>
-      <BaseLayout>
-        <Switch>
-          <Route path="/ipfs/:hash" component={Ipfs} />
-          <Route path={['/', '/ipfs']} component={IpfsList} />
-        </Switch>
-      </BaseLayout>
-    </Router>
+    <UserContext.Provider value={{ isLoggedIn, login, logout }}>
+      <Router>
+        <BaseLayout>
+          <Switch>
+            <Route path="/login" component={Login} />
+            <ProtectedRoute path="/ipfs/:hash" component={Ipfs} />
+            <ProtectedRoute path={['/', '/ipfs']} component={IpfsList} />
+          </Switch>
+        </BaseLayout>
+      </Router>
+    </UserContext.Provider>
   );
 }
 

--- a/src/components/layouts/BaseLayout/BaseLayout.tsx
+++ b/src/components/layouts/BaseLayout/BaseLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Container } from 'semantic-ui-react';
-import NavigationBar from '../NavigationBar';
+import { NavigationBar } from '../NavigationBar';
 
 interface BaseLayoutProps {
   children: any;

--- a/src/components/layouts/NavigationBar/NavigationBar.tsx
+++ b/src/components/layouts/NavigationBar/NavigationBar.tsx
@@ -32,7 +32,7 @@ const NavigationBar = (): JSX.Element => {
         {userContext.isLoggedIn ? (
           <div className="navigation-bar__user">
             {/* TODO: Need to have this as a small menu showing up */}
-            <a className="navigation-bar__link navigation-bar__user-link" onClick={logout} href="/">
+            <a className="navigation-bar__link navigation-bar__user-link" onClick={logout} href="/login">
               <FaUserCircle />
             </a>
           </div>

--- a/src/components/layouts/NavigationBar/NavigationBar.tsx
+++ b/src/components/layouts/NavigationBar/NavigationBar.tsx
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { FaUserCircle } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
-
+import UserContext from '../../../hooks/UserContext';
 import './NavigationBar.scss';
 
 const NavigationBar = (): JSX.Element => {
+  const userContext = useContext(UserContext);
+
+  const logout = (): void => {
+    userContext.logout();
+  };
+
   return (
     <div className="navigation-bar">
       <nav className="navigation-bar__nav">
@@ -23,12 +29,16 @@ const NavigationBar = (): JSX.Element => {
             </ul>
           </div>
         </div>
-        <div className="navigation-bar__user">
-          {/* TODO: Need to be a user page */}
-          <a className="navigation-bar__link navigation-bar__user-link" href="/">
-            <FaUserCircle />
-          </a>
-        </div>
+        {userContext.isLoggedIn ? (
+          <div className="navigation-bar__user">
+            {/* TODO: Need to have this as a small menu showing up */}
+            <a className="navigation-bar__link navigation-bar__user-link" onClick={logout} href="/">
+              <FaUserCircle />
+            </a>
+          </div>
+        ) : (
+          ''
+        )}
       </nav>
     </div>
   );

--- a/src/components/layouts/NavigationBar/index.ts
+++ b/src/components/layouts/NavigationBar/index.ts
@@ -1,0 +1,1 @@
+export { default as NavigationBar } from './NavigationBar';

--- a/src/components/layouts/NavigationBar/index.tsx
+++ b/src/components/layouts/NavigationBar/index.tsx
@@ -1,3 +1,0 @@
-import NavigationBar from './NavigationBar';
-
-export default NavigationBar;

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,0 +1,5 @@
+export const apis = {
+  // TODO: Replace this by the BE api urls we would be using. Probably storing this in a config file
+  url: 'https://jsonplaceholder.typicode.com',
+  timeout: 2 * 60 * 1000, // 2 minutes timeout
+};

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,2 @@
+export { apis } from './api';
+export { storageNames } from './storage-names';

--- a/src/config/storage-names.ts
+++ b/src/config/storage-names.ts
@@ -1,0 +1,3 @@
+export const storageNames = {
+  user: 'pl11',
+};

--- a/src/hooks/UserContext.ts
+++ b/src/hooks/UserContext.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+interface UserContextState {
+  isLoggedIn: boolean;
+  login: (token: string) => void;
+  logout: () => void;
+}
+
+const UserContext = createContext({} as UserContextState);
+
+export default UserContext;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as UserContext } from './UserContext';

--- a/src/pages/Login/Login.scss
+++ b/src/pages/Login/Login.scss
@@ -1,0 +1,72 @@
+$elevation-card: 0 0 1px 0 rgba(8, 11, 14, 0.6), 0 16px 16px -1px rgba(8, 11, 14, 0.1);
+$color-secondary: #e1e4e8;
+
+.login {
+  &__card {
+    max-width: 400px;
+    margin: auto;
+    box-shadow: $elevation-card;
+    padding: 30px;
+    background: white;
+  }
+
+  &__title {
+    font-size: 22px;
+    line-height: 32px;
+    font-weight: 500;
+    text-align: center;
+    margin: 8px 0 20px;
+    font-weight: bold;
+  }
+
+  &__input-container {
+    position: relative;
+    margin-top: 20px;
+  }
+
+  &__input {
+    border-radius: 100px;
+    border: 1px solid $color-secondary;
+    font-size: 14px;
+    line-height: 24px;
+    font-weight: 500;
+    height: 40px;
+    width: 100%;
+    outline: none;
+    padding: 0 15px;
+  }
+
+  &__input-icon {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: transparent;
+    border: none;
+    outline: none;
+    display: inline-block;
+    padding: 10px;
+    color: $color-secondary;
+  }
+
+  &__password-icon {
+    color: black;
+    cursor: pointer;
+  }
+
+  &__button {
+    border-radius: 100px;
+    font-size: 14px;
+    line-height: 24px;
+    background: black;
+    color: white;
+    padding: 0 10px;
+    height: 40px;
+    width: 100%;
+    border: none;
+    margin-top: 40px;
+    cursor: pointer;
+    padding: 0 20px;
+    outline: none;
+  }
+}

--- a/src/pages/Login/Login.scss
+++ b/src/pages/Login/Login.scss
@@ -1,5 +1,6 @@
 $elevation-card: 0 0 1px 0 rgba(8, 11, 14, 0.6), 0 16px 16px -1px rgba(8, 11, 14, 0.1);
 $color-secondary: #e1e4e8;
+$error-color: red;
 
 .login {
   &__card {
@@ -34,6 +35,16 @@ $color-secondary: #e1e4e8;
     width: 100%;
     outline: none;
     padding: 0 15px;
+
+    &--error {
+      border-color: $error-color;
+    }
+  }
+
+  &__input-error-msg {
+    font-size: 12px;
+    margin-left: 15px;
+    color: $error-color;
   }
 
   &__input-icon {

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -50,7 +50,7 @@ const Login = (props: RouteComponentProps<{}, {}, LoginProps>): JSX.Element => {
     }));
   };
 
-  const login = async (data: LoginFormData): Promise<any> => {
+  const login = (data: LoginFormData): void => {
     // Avoid the page to refresh from submitting the form
     // event.preventDefault();
     // TODO: put like a loading icon on the login button
@@ -59,7 +59,7 @@ const Login = (props: RouteComponentProps<{}, {}, LoginProps>): JSX.Element => {
 
     console.log('data', data);
     // Just to check
-    await paralinkApi
+    paralinkApi
       // For now this is going to be the placeholder
       .get('https://jsonplaceholder.typicode.com/todos')
       .then(() => {

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,0 +1,108 @@
+import React, { useContext } from 'react';
+import { FaEnvelope, FaEye, FaEyeSlash } from 'react-icons/fa';
+import { Redirect, RouteComponentProps } from 'react-router-dom';
+import UserContext from '../../hooks/UserContext';
+import paralinkApi from '../../services/interceptor';
+import './Login.scss';
+
+interface LoginProps {
+  from: string;
+}
+
+const Login = (props: RouteComponentProps<{}, {}, LoginProps>): JSX.Element => {
+  const userContext = useContext(UserContext);
+
+  const [state, setState] = React.useState({
+    email: '',
+    password: '',
+    seePassword: false,
+  });
+
+  const { from } = props.location.state || { from: { pathname: '/' } };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const { id, value } = e.target;
+    setState((prevState) => ({
+      ...prevState,
+      [id]: value,
+    }));
+  };
+
+  const togglePassword = (): void => {
+    setState((prevState) => ({
+      ...prevState,
+      seePassword: !prevState.seePassword,
+    }));
+  };
+
+  const login = async (): Promise<any> => {
+    // TODO: put like a loading icon on the login button
+
+    // TODO: do like a safe check on the email & password here
+
+    // Just to check
+    await paralinkApi
+      // For now this is going to be the placeholder
+      .get('https://jsonplaceholder.typicode.com/todos')
+      .then(() => {
+        // We should get the login token here from the BE
+        const token = 'faketokenhere';
+        userContext.login(token);
+      })
+      .catch((err: any) => {
+        // TODO: Need to display the error in the UI ( user not found, not correct password, not correct email)
+        console.error(err);
+      })
+      .finally(() => {
+        // TODO: login loading should be set to false here
+      });
+  };
+
+  if (userContext.isLoggedIn) {
+    return <Redirect to={from} />;
+  }
+
+  // TODO: handle pressing enter to submit ( maybe having it as a form instead and using submit )
+  return (
+    <div className="login__card">
+      <div className="login__title">Login into your account</div>
+      <div className="login__input-container">
+        <input
+          type="email"
+          className="login__email login__input"
+          id="email"
+          aria-describedby="emailHelp"
+          placeholder="myemail@gmail.com"
+          value={state.email}
+          onChange={handleChange}
+        />
+        <div className="login__input-icon">
+          <FaEnvelope className="login__email-icon" />
+        </div>
+      </div>
+      <div className="login__input-container">
+        <input
+          type={state.seePassword ? 'text' : 'password'}
+          className="login__password login__input"
+          id="password"
+          placeholder="Password"
+          value={state.password}
+          onChange={handleChange}
+        />
+
+        <button className="login__input-icon" type="button" onClick={togglePassword}>
+          {state.seePassword ? (
+            <FaEyeSlash className="login__password-icon" />
+          ) : (
+            <FaEye className="login__password-icon" />
+          )}
+        </button>
+      </div>
+      <button className="login__button" type="submit" onClick={login}>
+        Login
+      </button>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,6 +1,9 @@
+import { yupResolver } from '@hookform/resolvers/yup';
 import React, { useContext } from 'react';
+import { useForm } from 'react-hook-form';
 import { FaEnvelope, FaEye, FaEyeSlash } from 'react-icons/fa';
 import { Redirect, RouteComponentProps } from 'react-router-dom';
+import * as yup from 'yup';
 import UserContext from '../../hooks/UserContext';
 import paralinkApi from '../../services/interceptor';
 import './Login.scss';
@@ -9,24 +12,36 @@ interface LoginProps {
   from: string;
 }
 
+type LoginFormData = {
+  email: string;
+  password: string;
+};
+
+const loginSchema = yup.object().shape({
+  email: yup.string().email().required(),
+  password: yup.string().required(), // We could define rules here for password if there are
+});
+
 const Login = (props: RouteComponentProps<{}, {}, LoginProps>): JSX.Element => {
   const userContext = useContext(UserContext);
+  const { register, handleSubmit, errors } = useForm<LoginFormData>({ resolver: yupResolver(loginSchema) });
 
   const [state, setState] = React.useState({
-    email: '',
-    password: '',
+    // email: '',
+    // password: '',
     seePassword: false,
   });
 
   const { from } = props.location.state || { from: { pathname: '/' } };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const { id, value } = e.target;
-    setState((prevState) => ({
-      ...prevState,
-      [id]: value,
-    }));
-  };
+  // const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+  //   const { id, value } = e.target;
+  //   setState((prevState) => ({
+  //     ...prevState,
+  //     [id]: value,
+  //   }));
+  //   console.log('errors', errors);
+  // };
 
   const togglePassword = (): void => {
     setState((prevState) => ({
@@ -35,11 +50,14 @@ const Login = (props: RouteComponentProps<{}, {}, LoginProps>): JSX.Element => {
     }));
   };
 
-  const login = async (): Promise<any> => {
+  const login = async (data: LoginFormData): Promise<any> => {
+    // Avoid the page to refresh from submitting the form
+    // event.preventDefault();
     // TODO: put like a loading icon on the login button
 
     // TODO: do like a safe check on the email & password here
 
+    console.log('data', data);
     // Just to check
     await paralinkApi
       // For now this is going to be the placeholder
@@ -66,41 +84,46 @@ const Login = (props: RouteComponentProps<{}, {}, LoginProps>): JSX.Element => {
   return (
     <div className="login__card">
       <div className="login__title">Login into your account</div>
-      <div className="login__input-container">
-        <input
-          type="email"
-          className="login__email login__input"
-          id="email"
-          aria-describedby="emailHelp"
-          placeholder="myemail@gmail.com"
-          value={state.email}
-          onChange={handleChange}
-        />
-        <div className="login__input-icon">
-          <FaEnvelope className="login__email-icon" />
+      <form onSubmit={handleSubmit(login)}>
+        <div className="login__input-container">
+          <input
+            type="email"
+            className={`login__email login__input ${errors.email?.message ? 'login__input--error' : ''}`}
+            ref={register({ required: true })}
+            id="email"
+            aria-describedby="emailHelp"
+            placeholder="myemail@gmail.com"
+            name="email"
+          />
+          <div className="login__input-icon">
+            <FaEnvelope className="login__email-icon" />
+          </div>
         </div>
-      </div>
-      <div className="login__input-container">
-        <input
-          type={state.seePassword ? 'text' : 'password'}
-          className="login__password login__input"
-          id="password"
-          placeholder="Password"
-          value={state.password}
-          onChange={handleChange}
-        />
+        {errors.email?.message ? <span className="login__input-error-msg">{errors.email?.message}</span> : ''}
 
-        <button className="login__input-icon" type="button" onClick={togglePassword}>
-          {state.seePassword ? (
-            <FaEyeSlash className="login__password-icon" />
-          ) : (
-            <FaEye className="login__password-icon" />
-          )}
+        <div className="login__input-container">
+          <input
+            type={state.seePassword ? 'text' : 'password'}
+            className={`login__password login__input ${errors.email?.message ? 'login__input--error' : ''}`}
+            ref={register({ required: true })}
+            id="password"
+            placeholder="Password"
+            name="password"
+          />
+
+          <button className="login__input-icon" type="button" onClick={togglePassword}>
+            {state.seePassword ? (
+              <FaEyeSlash className="login__password-icon" />
+            ) : (
+              <FaEye className="login__password-icon" />
+            )}
+          </button>
+        </div>
+        {errors.password?.message ? <span className="login__input-error-msg">{errors.password?.message}</span> : ''}
+        <button className="login__button" type="submit">
+          Login
         </button>
-      </div>
-      <button className="login__button" type="submit" onClick={login}>
-        Login
-      </button>
+      </form>
     </div>
   );
 };

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,0 +1,1 @@
+export { default as Login } from './Login';

--- a/src/services/interceptor/auth.ts
+++ b/src/services/interceptor/auth.ts
@@ -1,0 +1,32 @@
+import axios from 'axios';
+import { apis, storageNames } from '../../config';
+
+const paralinkApi = axios.create({
+  baseURL: apis.url,
+  timeout: apis.timeout,
+});
+
+paralinkApi.interceptors.request.use(
+  (config: any) => {
+    // Check for user token
+    const accessToken = localStorage.getItem(storageNames.user);
+
+    // If user not logged we just pass it through, the backend should not accept it
+    // This lets us do api requests like for logging in for example.
+    // Depending on the API we could potentially reject here before doing the call and add an exception for login path
+    if (!accessToken) {
+      return config;
+    }
+
+    // Otherwise set the token in the request
+    const request = config;
+    request.headers.authorization = `Bearer ${accessToken}`;
+    return request;
+  },
+  (error) => {
+    // User might have been rejected
+    return Promise.reject(error);
+  },
+);
+
+export default paralinkApi;

--- a/src/services/interceptor/auth.ts
+++ b/src/services/interceptor/auth.ts
@@ -8,7 +8,7 @@ const paralinkApi = axios.create({
 
 paralinkApi.interceptors.request.use(
   (config: any) => {
-    // Check for user token
+    // Check for user token, we can't use hooks from here
     const accessToken = localStorage.getItem(storageNames.user);
 
     // If user not logged we just pass it through, the backend should not accept it

--- a/src/services/interceptor/index.ts
+++ b/src/services/interceptor/index.ts
@@ -1,0 +1,3 @@
+import paralinkApi from './auth';
+
+export default paralinkApi;

--- a/src/shared/ProtectedRoute/ProtectedRoute.tsx
+++ b/src/shared/ProtectedRoute/ProtectedRoute.tsx
@@ -1,0 +1,28 @@
+import React, { useContext } from 'react';
+import { Redirect, Route } from 'react-router-dom';
+import UserContext from '../../hooks/UserContext';
+
+// Disable the eslint for next any
+// eslint-disable-next-line
+const ProtectedRoute = ({ component: Component, ...rest }: any): JSX.Element => {
+  const userContext = useContext(UserContext);
+  /** Verify that user is logged in otherwise redirect to login page */
+  return (
+    <Route
+      {...rest}
+      render={(props) =>
+        userContext.isLoggedIn ? (
+          <Component {...props} />
+        ) : (
+          <Redirect
+            to={{
+              pathname: '/login',
+              state: { from: props.location },
+            }}
+          />
+        )
+      }
+    />
+  );
+};
+export default ProtectedRoute;

--- a/src/shared/ProtectedRoute/index.tsx
+++ b/src/shared/ProtectedRoute/index.tsx
@@ -1,0 +1,1 @@
+export { default as ProtectedRoute } from './ProtectedRoute';


### PR DESCRIPTION
Still need to do : 

- [ ] Refine the login component and the layout
- [ ] Hook this to the api once live & having a way to detect the expiration
- [ ] Potentially hooking for the refresh token
- [ ] Address all the todos in the code 
- [ ] Adding unit tests for this

# Changes
- Added the login screen & route
- Added some based for the authentication interceptor & redirection
# Screenshots
<img width="496" alt="Screenshot 2021-02-14 at 17 57 45" src="https://user-images.githubusercontent.com/6785920/107888727-0b991200-6f06-11eb-97dd-b5d75b79789c.png">

![Screenshot 2021-02-14 at 19 56 30](https://user-images.githubusercontent.com/6785920/107888738-19e72e00-6f06-11eb-9a48-5ec66692bed1.png)

![Screenshot 2021-02-14 at 19 56 35](https://user-images.githubusercontent.com/6785920/107888739-1b185b00-6f06-11eb-8e51-725e36ec5cd4.png)
